### PR TITLE
Added matchExpressions: section to values hub definitions

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -130,17 +130,28 @@ clusterGroup:
   - name: devel
     helmOverrides:
     - name: clusterGroup.isHubCluster
-      value: false
+      value: "false"
     clusterSelector:
       matchLabels:
         clusterGroup: devel
+      matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
+
   - name: secured
     helmOverrides:
     - name: clusterGroup.isHubCluster
-      value: false
+      value: "false"
     clusterSelector:
       matchLabels:
         clusterGroup: secured
+      matchExpressions:
+      - key: vendor
+        operator: In
+        values:
+          - OpenShift
 
 
 # I don't think this is needed but let's check


### PR DESCRIPTION
The values for helmOverrides need to be strings.
Added  matchExpressions section to each of the managedClusterGroups.
  matchExpressions:
      - key: vendor
        operator: In
        values:
          - OpenShift
