### PR TITLE
Clean up script

### DIFF
--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -8,79 +8,76 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   create-quaye-pull-secret.sh: |
-    #!/bin/bash -ex
-    echo "[INFO] QUAYORG: $QUAYORG QUAYUSER: $QUAYUSER"
-    oc delete --ignore-not-found=true secret quay-temp-token
+      #!/bin/bash -ex
+      echo "[INFO] QUAYORG: $QUAYORG QUAYUSER: $QUAYUSER"
+      if [ -z "$QUAYHOST" ]; then
+          QUAYHOST=https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}
+      fi
+      if [ -z "$QUAYUSER" ]; then
+          QUAYUSER=admin
+      fi
+      if [ -z "$QUAYEMAIL" ]; then
+          QUAYEMAIL=devel@your.com
+      fi
+      if [ -z "$QUAYORG" ]; then
+          QUAYORG=devel
+      fi
+      if [ -z "$QUAYREPO" ]; then
+          QUAYREPO=$QUAYORG
+      fi
 
-    echo "[INFO] Creating Quay default user not created..."  
-    # Invoke API and add quay user to the API - initiates API
-    JSONTOKEN=$(curl -X POST -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/user/initialize --header 'Content-Type: application/json' --data '{ "username": "{{ .Values.global.quay.account }}", "password":"{{ .Values.global.quay.password }}", "email": "$QUAYEMAIL", "access_token": true}')
-    echo "[INFO] TOKEN: $JSONTOKEN"
-    oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
-    echo "quay-temp-token created"
+      #  '-n quay-enterprise' is implied
+      COUNT=$(oc get --ignore-not-found=true secret quay-temp-token | wc -l) 
+      if [ $COUNT = 0 ]; then
+          echo "[INFO] Creating Quay default user..."
+          # Invoke API and add quay user to the API - initiates API
+          # TODO: Password should come from a Vault (via a Secret)!!
+          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data '{ "username": "$QUAYUSER", "password":"{{ .Values.global.quay.password }}", "email": "$QUAYEMAIL", "access_token": true}')
 
-    echo "[INFO] Secret quay-integration not created. Creating ..."  
-    # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
-    TOKEN=$(oc extract secret/quay-temp-token --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
-    if [ $? -eq 0 ]; then
-      echo "[INFO] TOKEN: $TOKEN"
-    else
-      echo "[ERROR] Trouble extracting TOKEN from quay-temp-token"
-      exit 2
-    fi
-    # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
-    echo "[INFO] Create organization $QUAYORG"
-    curl -X POST -k --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/organization/ --data '{"name": "{{ .Values.devel.quayorg }}", "email": "{{ .Values.devel.quayorgemail }}" }'
-    echo "[INFO] Org creation status: $?"
-    if [ $? -eq 0 ]; then
-      echo "[INFO] Creating a repo ..."
-      curl -X POST -k --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/repository --data '{"namespace": "{{ .Values.devel.quayorg }}","repository": "{{ .Values.devel.quayorg }}","visibility":"public","description":"Development Repo","repo_kind":"image"}'
-      if [ $? -eq 0 ]; then
-        echo "[INFO] Repo created"
-      else 
-        echo "[WARNING] Could not create repo"
-        exit 2
+          oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
+          echo "quay-temp-token created"
       fi
-      echo "[INFO] Creating a user ..."
-      USERTOKEN=$(curl -X POST -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/superuser/users/ -H "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' --data '{ "username": "{{ .Values.devel.quayuser }}", "email": "{{ .Values.devel.quayuseremail }}", "access_token": true}')
-      echo $USERTOKEN
-      if [ $? -eq 0 ]; then
-        echo "[INFO] User created"
-      else 
-        echo "[WARNING] Could not create User"
-        exit 2
+      
+      TOKEN=$(oc extract secret/quay-temp-token --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
+      CURL_OPTS="--fail -k"
+
+      COUNT=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
+      if [ $COUNT = 0 ]; then
+          echo "[INFO] Creating a superuser ..."
+          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ --data '{ "username": "$QUAYUSER", "email": "$QUAYEMAIL", "access_token": true}')
+          QUAYPASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
+
+          echo "[INFO] Creating a secret with user/password ..."
+          oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USERTOKEN"
+
+          BASE64AUTH=`echo $QUAYUSER:$QUAYPASSWORD | base64 -w0`
+          echo -e "{  \"auths\": {    \"$QUAYHOST\": {    \"auth\": \"$BASE64AUTH\"    }  }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
       fi
-      QUAYPASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
-      echo "[INFO] Creating a secret with user/password ..."
-      oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USERTOKEN"
-      if [ $? -eq 0 ]; then
-        echo "[INFO] User secret created"
-      else 
-        echo "[WARNING] Could not create secret quay-user."
-        exit 2
+      
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG | grep -v not_found | wc -l)
+      if [ $COUNT = 0 ]; then
+        # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
+        # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
+        echo "[INFO] Create organization $QUAYORG"
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data '{"name": "$QUAYORG", "email": "$QUAYEMAIL" }'
       fi
-      echo "[INFO] Associating $QUAYUSER with $QUAYORG"
-      OUTPUT=$(curl -X PUT -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/organization/$QUAYORG/team/owners/members/$QUAYUSER -H "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' --data '{}')
-      if [ $? -eq 0 ]; then
-        echo "[INFO] Output: $OUTPUT"
-      else 
-        echo "[ERROR] Could not associate user $QUAYUSER with org. $QUAYORG"
-        exit 2
+
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
+      if [ $COUNT = 0 ]; then
+            echo "[INFO] Creating a repo ..."
+            curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data '{"namespace":"$QUAYORG", "repository":"$QUAYREPO", "visibility":"public", "description":"Development Repo", "repo_kind":"image"}'
       fi
-      echo "[INFO] Give $QUAYUSER admin rights to the repo"
-      OUTPUT=$(curl -X PUT -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/repository/$QUAYORG/$QUAYORG/permissions/user/$QUAYUSER -H "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' --data '{ "role": "admin"}')
-      if [ $? -eq 0 ]; then
-        echo "[INFO] Output: $OUTPUT"
-      else 
-        echo "[ERROR] Could not $QUAYUSER admin rights"
-        exit 2
+            
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/team/owners/members | grep "name\": \"$QUAYUSER\"" | wc -l)
+      if [ $COUNT = 0 ]; then
+          echo "[INFO] Associating $QUAYUSER with $QUAYORG"
+          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/team/owners/members/$QUAYUSER --data '{}'
       fi
-      BASE64AUTH=`echo $QUAYUSER:$QUAYPASSWORD | base64 -w0`
-      echo "[INFO] BASE64AUTH=$BASE64AUTH"
-      echo -e "{\n  \"auths\": {\n    \"https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}\": {\n    \"auth\": \"$BASE64AUTH\"\n    }\n  }\n}"
-      echo -e "{  \"auths\": {    \"https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}\": {    \"auth\": \"$BASE64AUTH\"    }  }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
-    else
-        echo "[ERROR] Problem with creating an organization in Quay pull secret!"
-        exit 2  
-    fi
-    echo "[INFO] Job finished"
+
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO/permissions/user/$QUAYUSER | grep '"role": "admin"' | wc -l)
+      if [ $COUNT = 0 ]; then
+          echo "[INFO] Give $QUAYUSER admin rights to the repo"
+          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO/permissions/user/$QUAYUSER --data '{ "role": "admin"}'
+      fi
+
+      echo "[INFO] Job finished"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -48,13 +48,13 @@ data:
           QUAY_USER_EMAIL={{ .Values.quay.setup.user.email }}
       fi
       if [ -z "$QUAY_ORG" ]; then
-          QUAY_ORG={{ .Values.quay.setup.org.name }}
+          QUAY_ORG={{ .Values.global.quay.org.name }}
       fi
       if [ -z "$QUAY_ORG_EMAIL" ]; then
-          QUAY_ORG_EMAIL={{ .Values.quay.setup.org.email }}
+          QUAY_ORG_EMAIL={{ .Values.global.quay.org.email }}
       fi
       if [ -z "$QUAY_REPO" ]; then
-          QUAY_REPO={{ .Values.quay.setup.repo }}
+          QUAY_REPO={{ .Values.global.quay.repo }}
       fi
 
       echo "[INFO] Looking for initial token ..."
@@ -114,7 +114,7 @@ data:
           # If it worked, we could create a new OAuth token when the original one expires after 150min
           ####
           # CLIENTID=$(quay_cmd Bearer GET /api/v1/organization/$QUAY_ORG/applications | sed -e 's/{/\n/g' | grep "\"name\": \"$APPLICATION\"" | sed -e 's/,/\n/g' | grep client_id | awk '{print $2}' | sed 's/"//g')
-          # quay_cmd PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
+          # quay_cmd Basic PUT "/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp"
       fi
 
       echo "[INFO] Looking for initial organization ..."
@@ -123,7 +123,7 @@ data:
         echo "[INFO] Creating $QUAY_ORG org ..."
         # Email cannot be shared with the initial user
         quay_cmd Bearer POST /api/v1/organization/ "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
-        quay_cmd Basic GET /api/v1/organization/$QUAY_ORG  
+        quay_cmd Basic GET /api/v1/organization/$QUAY_ORG
       fi
 
       echo "[INFO] Looking for org application ..."

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -9,21 +9,18 @@ metadata:
 data:
   create-quaye-pull-secret.sh: |
       #!/bin/bash -ex
-      echo "[INFO] QUAYORG: $QUAYORG QUAYUSER: $QUAYUSER"
-      if [ -z "$QUAYHOST" ]; then
-          QUAYHOST=https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}
+      env | grep QUAY
+      if [ -z "$QUAY_HOST" ]; then
+          QUAY_HOST=https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}
       fi
-      if [ -z "$QUAYUSER" ]; then
-          QUAYUSER=admin
+      if [ -z "$QUAY_USER" ]; then
+          QUAY_USER=admin
       fi
-      if [ -z "$QUAYEMAIL" ]; then
-          QUAYEMAIL=devel@your.com
+      if [ -z "$QUAY_ORG" ]; then
+          QUAY_ORG=devel
       fi
-      if [ -z "$QUAYORG" ]; then
-          QUAYORG=devel
-      fi
-      if [ -z "$QUAYREPO" ]; then
-          QUAYREPO=$QUAYORG
+      if [ -z "$QUAY_REPO" ]; then
+          QUAY_REPO=$QUAY_ORG
       fi
 
       #  '-n quay-enterprise' is implied
@@ -33,7 +30,7 @@ data:
           echo "[INFO] Creating default user..."
           # Invoke API and add quay user to the API - initiates API
           # TODO: Password should come from a Vault (via a Secret)!!
-          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"quay\", \"password\":\"{{ .Values.global.quay.password }}\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
+          JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"{{ .Values.quay.setup.admin.password }}\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
 
           oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
           echo "quay-init-token created"
@@ -46,53 +43,53 @@ data:
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
       
       echo "[INFO] Looking for initial organization ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG | grep -v not_found | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
         # Email cannot be shared with the initial user?  
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"org+$QUAYEMAIL\" }"
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
 
       echo "[INFO] Looking for org application ..."
       # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
       APPLICATION=automation
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/applications | grep $APPLICATION | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/applications --data "{\"name\": \"$QUAYORG-automation\", \"description\": \"automation app\" }"
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
       fi
       
       echo "[INFO] Looking for initial repo ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data "{\"namespace\":\"$QUAYORG\", \"repository\":\"$QUAYREPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
+          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
       fi
 
       echo "[INFO] Looking for our superuser ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep $QUAY_USER | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAYUSER\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
-          QUAYPASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
+          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
+          QUAY_PASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
 
           echo "[INFO] Creating a secret with user/password ..."
           oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USERTOKEN"
 
-          BASE64AUTH=`echo $QUAYUSER:$QUAYPASSWORD | base64 -w0`
-          echo -e "{ \"auths\": { \"$QUAYHOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
+          BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
+          echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/team/owners/members | grep "name\": \"$QUAYUSER\"" | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Associating $QUAYUSER with $QUAYORG"
-          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/team/owners/members/$QUAYUSER --data '{}'
+          echo "[INFO] Associating $QUAY_USER with $QUAY_ORG"
+          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER --data '{}'
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO/permissions/user/$QUAYUSER | grep '"role": "admin"' | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Give $QUAYUSER admin rights to the repo"
-          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO/permissions/user/$QUAYUSER --data '{ "role": "admin"}'
+          echo "[INFO] Give $QUAY_USER admin rights to the repo"
+          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'
       fi
 
       echo "[INFO] Job finished"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -8,19 +8,21 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   create-quaye-pull-secret.sh: |
-      #!/bin/bash -ex
+      #!/bin/bash -e
 
       function quay_cmd() {
           DATA='{}'
           if [ ! -z "$3" ]; then
               DATA=$3
           fi
+          # Avoid logging the token for security reasons, DATA may contain sensitive info though :-/
+          echo "[INFO] $1 $2 --data $DATA" 1>&2
           curl -X $1 $CURL_OPTS -H 'Content-Type: application/json'  -H "Authorization: Bearer $TOKEN" $QUAY_HOST$2 --data "$DATA"
       }
 
-      CURL_OPTS="-fSk"
+      CURL_OPTS="-fsk"
 
-      env | grep QUAY
+      env | grep QUAY | grep -v QUAY_REGISTRY
       if [ -z "$QUAY_HOST" ]; then
           QUAY_HOST="https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}"
       fi
@@ -45,8 +47,6 @@ data:
       SECRET_NAME=quay-init-token
       COUNT=$(oc get --ignore-not-found=true secret $SECRET_NAME | wc -l) 
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Creating default user..."
-
           INITPASS=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo ''  )
 
           echo "[INFO] Destroy any previous secrets ..."
@@ -54,10 +54,11 @@ data:
           oc delete --ignore-not-found=true secret -n openshift-operators quay-pull-secret  
 
           # Invoke API and add quay user to the API - initiates API
+          echo "[INFO] Creating default user..."
           JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"$INITPASS\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
 
+          echo "[INFO] Creating $SECRET_NAME ..."
           oc create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN --from-literal=password=$INITPASS
-          echo "quay-init-token created"
       fi
       
       TOKEN=$(oc extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
@@ -67,7 +68,8 @@ data:
 
       echo "[INFO] Checking our bearer token is still valid ..."
       COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
-      if [ $COUNT = 0 ]; then    
+      if [ $COUNT = 0 ]; then
+          # Either the super user doesn't exist, or the token is invalid... determine which...
           COUNT=$(oc get --ignore-not-found=true secret quay-user | wc -l) 
           if [ $COUNT -gt 1 ]; then
               BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
@@ -75,46 +77,37 @@ data:
               # This call can be used without a token to show that quay is configured
               COUNT=$(curl -X GET $CURL_OPTS -H 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
               if [ $COUNT -gt 0 ]; then
+                  # We found the quay-user secret, with valid basic auth details, and the organization... conclude the bearer token has expired (150min lifetime)
                   echo "Bearer token has expired"
                   exit 0
               fi
           fi
-      fi      
+      fi
 
       echo "[INFO] Looking for initial organization ..."
       COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
-        echo "[INFO] Creating..."
+        echo "[INFO] Creating $QUAY_ORG org ..."
         # Email cannot be shared with the initial user
         quay_cmd POST /api/v1/organization/  "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
-      
-      echo "[INFO] Looking for org application ..."
-      # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
-      APPLICATION=automation
-      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
-      if [ $COUNT = 0 ]; then
-        echo "[INFO] Creating..."
-        quay_cmd POST /api/v1/organization/$QUAY_ORG/applications "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
-      fi
 
       echo "[INFO] Looking for our superuser ..."
+      # Org must exist first?  Makes no sense, but it seems to be true
       COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then    
-          echo "[INFO] Creating..."
+          echo "[INFO] Creating $QUAY_USER user ..."
           RESPONSE=$(quay_cmd POST /api/v1/superuser/users/ "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
 
           QUAY_PASSWORD=$(echo $RESPONSE | cut -d : -f5 | awk -F\} '{print $1}')
           BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
 
-          echo "[INFO] Creating a secret with user/password ..."
+          echo "[INFO] Creating quay-user secret ..."
           oc create secret -n quay-enterprise generic quay-user --from-literal=token="$RESPONSE" --from-literal=basic="$BASE64AUTH"
 
+          echo "[INFO] Creating quay-pull-secret ..."
           echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
 
-          BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
-          curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG
-          
           # https://access.redhat.com/solutions/5462311
           # Requires CLIENTID to be added to DIRECT_OAUTH_CLIENTID_WHITELIST for this to work
           # If it worked, we could create a new OAuth token when the original one expires after 150min
@@ -123,24 +116,38 @@ data:
           # quay_cmd PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
       fi
 
+      BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
+      curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG  
+      
+      echo "[INFO] Looking for org application ..."
+      # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token
+      # If there was a programatic way to do it here, we could avoid the problem with the bearer token expiring after 150min
+      APPLICATION=automation
+      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
+      if [ $COUNT = 0 ]; then
+        echo "[INFO] Creating..."
+        quay_cmd POST /api/v1/organization/$QUAY_ORG/applications "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
+      fi
+
       echo "[INFO] Looking for initial repo ..."
       COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Creating..."
+          echo "[INFO] Creating $QUAY_REPO repo..."
           quay_cmd POST /api/v1/repository "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"  
       fi
 
+      echo "[INFO] Looking for $QUAY_ORG members ..."
       COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Associating $QUAY_USER with $QUAY_ORG"
+          echo "[INFO] Associating $QUAY_USER with $QUAY_ORG ..."
           quay_cmd PUT /api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER '{}'
       fi
 
+      echo "[INFO] Looking for $QUAY_REPO admins ..."
       COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Give $QUAY_USER admin rights to the repo"
+          echo "[INFO] Give $QUAY_USER admin rights to the repo ..."
           quay_cmd PUT /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER '{ "role": "admin"}'
       fi
-
 
       echo "[INFO] Job finished"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -55,6 +55,23 @@ data:
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
 
+      echo "[INFO] Looking for initial organization ..."
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
+      if [ $COUNT = 0 ]; then
+        echo "[INFO] Creating..."
+        # Email cannot be shared with the initial user
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+      fi
+      
+      echo "[INFO] Looking for org application ..."
+      # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
+      APPLICATION=automation
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
+      if [ $COUNT = 0 ]; then
+        echo "[INFO] Creating..."
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
+      fi
+
       echo "[INFO] Looking for our superuser ..."
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then
@@ -90,23 +107,6 @@ data:
           ####
           # CLIENTID=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | sed -e 's/{/\n/g' | grep "\"name\": \"$APPLICATION\"" | sed -e 's/,/\n/g' | grep client_id | awk '{print $2}' | sed 's/"//g')
           # curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
-      fi
-
-      echo "[INFO] Looking for initial organization ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
-      if [ $COUNT = 0 ]; then
-        echo "[INFO] Creating..."
-        # Email cannot be shared with the initial user
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
-      fi
-
-      echo "[INFO] Looking for org application ..."
-      # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
-      APPLICATION=automation
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
-      if [ $COUNT = 0 ]; then
-        echo "[INFO] Creating..."
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
       fi
 
       echo "[INFO] Looking for initial repo ..."

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -41,6 +41,14 @@ data:
       TOKEN=$(oc extract secret/quay-temp-token --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
       CURL_OPTS="--fail -k"
 
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG | grep -v not_found | wc -l)
+      if [ $COUNT = 0 ]; then
+        # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
+        # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
+        echo "[INFO] Create organization $QUAYORG"
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"$QUAYEMAIL\" }"
+      fi
+
       COUNT=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating a superuser ..."
@@ -53,15 +61,6 @@ data:
           BASE64AUTH=`echo $QUAYUSER:$QUAYPASSWORD | base64 -w0`
           echo -e "{  \"auths\": {    \"$QUAYHOST\": {    \"auth\": \"$BASE64AUTH\"    }  }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
       fi
-      
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG | grep -v not_found | wc -l)
-      if [ $COUNT = 0 ]; then
-        # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
-        # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
-        echo "[INFO] Create organization $QUAYORG"
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"$QUAYEMAIL\" }"
-      fi
-
 
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -72,13 +72,13 @@ data:
           fi
           
           echo "[INFO] Creating..."
-          USER=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
+          RESPONSE=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
 
-          QUAY_PASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
+          QUAY_PASSWORD=$(echo $RESPONSE | cut -d : -f5 | awk -F\} '{print $1}')
           BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
 
           echo "[INFO] Creating a secret with user/password ..."
-          oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USER" --from-literal=basic="$BASE64AUTH"
+          oc create secret -n quay-enterprise generic quay-user --from-literal=token="$RESPONSE" --from-literal=basic="$BASE64AUTH"
 
           echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
 

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -44,40 +44,40 @@ data:
       fi
       
       TOKEN=$(oc extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
-      CURL_OPTS="--fail -k"
+      CURL_OPTS="--fail -k  --header 'Content-Type: application/json'"
 
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
       
       echo "[INFO] Looking for initial organization ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
         # Email cannot be shared with the initial user?  
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+        curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
 
       echo "[INFO] Looking for org application ..."
       # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
       APPLICATION=automation
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
+        curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
       fi
       
       echo "[INFO] Looking for initial repo ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
+          curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
       fi
 
       echo "[INFO] Looking for our superuser ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep $QUAY_USER | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep $QUAY_USER | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
+          USERTOKEN=$(curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
           QUAY_PASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
 
           echo "[INFO] Creating a secret with user/password ..."
@@ -87,16 +87,16 @@ data:
           echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Associating $QUAY_USER with $QUAY_ORG"
-          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER --data '{}'
+          curl -X PUT $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER --data '{}'
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Give $QUAY_USER admin rights to the repo"
-          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'
+          curl -X PUT $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'
       fi
 
       echo "[INFO] Job finished"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -74,7 +74,7 @@ data:
       fi
 
       echo "[INFO] Looking for our superuser ..."
-      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep $QUAY_USER | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
           USERTOKEN=$(curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -9,6 +9,11 @@ metadata:
 data:
   create-quaye-pull-secret.sh: |
       #!/bin/bash -ex
+
+      function quay_cmd() {
+          curl -X $1 --fail -k --header 'Content-Type: application/json'  -H "Authorization: Bearer $3" $QUAY_HOST$2
+      }
+
       env | grep QUAY
       if [ -z "$QUAY_HOST" ]; then
           QUAY_HOST="https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}"
@@ -56,7 +61,8 @@ data:
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
 
       echo "[INFO] Looking for initial organization ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
+      #COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
+      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG $TOKEN | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
         # Email cannot be shared with the initial user
@@ -82,7 +88,7 @@ data:
           fi
           
           # This call can be used without a token to show that quay is configured
-          COUNT=$(curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
+          COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
           if [ $COUNT = 1 ]; then
               echo "Bearer token has expired"
               exit 0
@@ -100,7 +106,7 @@ data:
           echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
 
           BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
-          COUNT=$(curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
+          curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG
           # https://access.redhat.com/solutions/5462311
           # Requires CLIENTID to be added to DIRECT_OAUTH_CLIENTID_WHITELIST for this to work
           # If it worked, we could create a new OAuth token when the original one expires after 150min

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -31,18 +31,19 @@ data:
 
       #  '-n quay-enterprise' is implied
       echo "[INFO] Looking for initial token ..."
-      COUNT=$(oc get --ignore-not-found=true secret quay-init-token | wc -l) 
+      SECRET_NAME=quay-init-token
+      COUNT=$(oc get --ignore-not-found=true secret $SECRET_NAME | wc -l) 
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating default user..."
           # Invoke API and add quay user to the API - initiates API
           # TODO: Password should come from a Vault (via a Secret)!!
           JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"{{ .Values.quay.setup.admin.password }}\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
 
-          oc create secret generic quay-init-token --from-literal=token=$JSONTOKEN
+          oc create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN
           echo "quay-init-token created"
       fi
       
-      TOKEN=$(oc extract secret/quay-temp-token --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
+      TOKEN=$(oc extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
       CURL_OPTS="--fail -k"
 
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -20,7 +20,7 @@ data:
           if [ $1 = "Basic" ]; then
               COUNT=$(oc -n $QUAY_NAMESPACE get --ignore-not-found=true secret $QUAY_USER_SECRET | wc -l) 
               if [ $COUNT -gt 1 ]; then
-                  BASIC=$(oc -n $QUAY_NAMESPACE --ignore-not-found=true extract secret/$QUAY_USER_SECRET --keys=basic --to=-)
+                  BASIC=$(oc -n $QUAY_NAMESPACE extract secret/$QUAY_USER_SECRET --keys=basic --to=-)
               fi
               AUTH="Authorization: Basic $BASIC"
 

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -11,7 +11,11 @@ data:
       #!/bin/bash -ex
 
       function quay_cmd() {
-          curl -X $1 --fail -k --header 'Content-Type: application/json'  -H "Authorization: Bearer $3" $QUAY_HOST$2
+          DATA='{}'
+          if [ ! -z "$3" ]; then
+              DATA=$3
+          fi
+          curl -X $1 --fail -k --header 'Content-Type: application/json'  -H "Authorization: Bearer $TOKEN" $QUAY_HOST$2 --data "$DATA"
       }
 
       env | grep QUAY
@@ -61,12 +65,12 @@ data:
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
 
       echo "[INFO] Looking for initial organization ..."
-      #COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
-      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG $TOKEN | grep -v not_found | wc -l)
+      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
         # Email cannot be shared with the initial user
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+        quay_cmd POST /api/v1/organization/$QUAY_ORG  "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+        #curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
       
       echo "[INFO] Looking for org application ..."
@@ -79,7 +83,7 @@ data:
       fi
 
       echo "[INFO] Looking for our superuser ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
+      COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then
 
           COUNT=$(oc get --ignore-not-found=true secret quay-user | wc -l) 
@@ -116,19 +120,19 @@ data:
       fi
 
       echo "[INFO] Looking for initial repo ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
+      COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
           curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"  
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
+      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Associating $QUAY_USER with $QUAY_ORG"
           curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER --data '{}'
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
+      COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Give $QUAY_USER admin rights to the repo"
           curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -11,16 +11,22 @@ data:
       #!/bin/bash -ex
       env | grep QUAY
       if [ -z "$QUAY_HOST" ]; then
-          QUAY_HOST=https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}
+          QUAY_HOST="https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}"
       fi
       if [ -z "$QUAY_USER" ]; then
-          QUAY_USER=admin
+          QUAY_USER={{ .Values.quay.setup.user.name }}
+      fi
+      if [ -z "$QUAY_USER_EMAIL" ]; then
+          QUAY_USER_EMAIL={{ .Values.quay.setup.user.email }}
       fi
       if [ -z "$QUAY_ORG" ]; then
-          QUAY_ORG=devel
+          QUAY_ORG={{ .Values.quay.setup.org.name }}
+      fi
+      if [ -z "$QUAY_ORG_EMAIL" ]; then
+          QUAY_ORG_EMAIL={{ .Values.quay.setup.org.email }}
       fi
       if [ -z "$QUAY_REPO" ]; then
-          QUAY_REPO=$QUAY_ORG
+          QUAY_REPO={{ .Values.quay.setup.repo }}
       fi
 
       #  '-n quay-enterprise' is implied

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -32,7 +32,7 @@ data:
           echo "[INFO] Creating Quay default user..."
           # Invoke API and add quay user to the API - initiates API
           # TODO: Password should come from a Vault (via a Secret)!!
-          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"$QUAYUSER\", \"password\":\"{{ .Values.global.quay.password }}\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
+          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"quayinit\", \"password\":\"{{ .Values.global.quay.password }}\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
 
           oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
           echo "quay-temp-token created"
@@ -46,7 +46,14 @@ data:
         # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
         # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
         echo "[INFO] Create organization $QUAYORG"
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"$QUAYEMAIL\" }"
+        # Email cannot be shared with the initial user?  
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"org+$QUAYEMAIL\" }"
+      fi
+
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
+      if [ $COUNT = 0 ]; then
+            echo "[INFO] Creating a repo ..."
+            curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data "{\"namespace\":\"$QUAYORG\", \"repository\":\"$QUAYREPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
       fi
 
       COUNT=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
@@ -62,12 +69,6 @@ data:
           echo -e "{  \"auths\": {    \"$QUAYHOST\": {    \"auth\": \"$BASE64AUTH\"    }  }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
-      if [ $COUNT = 0 ]; then
-            echo "[INFO] Creating a repo ..."
-            curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data "{\"namespace\":\"$QUAYORG\", \"repository\":\"$QUAYREPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
-      fi
-            
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/team/owners/members | grep "name\": \"$QUAYUSER\"" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Associating $QUAYUSER with $QUAYORG"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -27,45 +27,52 @@ data:
       fi
 
       #  '-n quay-enterprise' is implied
-      COUNT=$(oc get --ignore-not-found=true secret quay-temp-token | wc -l) 
+      echo "[INFO] Looking for initial token ..."
+      COUNT=$(oc get --ignore-not-found=true secret quay-init-token | wc -l) 
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Creating Quay default user..."
+          echo "[INFO] Creating default user..."
           # Invoke API and add quay user to the API - initiates API
           # TODO: Password should come from a Vault (via a Secret)!!
-          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"quayinit\", \"password\":\"{{ .Values.global.quay.password }}\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
+          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"quay\", \"password\":\"{{ .Values.global.quay.password }}\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
 
           oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
-          echo "quay-temp-token created"
+          echo "quay-init-token created"
       fi
       
       TOKEN=$(oc extract secret/quay-temp-token --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
       CURL_OPTS="--fail -k"
 
+      # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
+      # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
+      
+      echo "[INFO] Looking for initial organization ..."
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
-        # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
-        # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
-        echo "[INFO] Create organization $QUAYORG"
+        echo "[INFO] Creating..."
         # Email cannot be shared with the initial user?  
         curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"org+$QUAYEMAIL\" }"
       fi
 
+      echo "[INFO] Looking for org application ..."
+      # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
       APPLICATION=automation
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/applications | grep $APPLICATION | wc -l)
       if [ $COUNT = 0 ]; then
-        echo "[INFO] Create $APPLICATION application"
+        echo "[INFO] Creating..."
         curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/applications --data "{\"name\": \"$QUAYORG-automation\", \"description\": \"automation app\" }"
       fi
       
+      echo "[INFO] Looking for initial repo ..."
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
-            echo "[INFO] Creating a repo ..."
-            curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data "{\"namespace\":\"$QUAYORG\", \"repository\":\"$QUAYREPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
+          echo "[INFO] Creating..."
+          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data "{\"namespace\":\"$QUAYORG\", \"repository\":\"$QUAYREPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
       fi
 
+      echo "[INFO] Looking for our superuser ..."
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
       if [ $COUNT = 0 ]; then
-          echo "[INFO] Creating a superuser ..."
+          echo "[INFO] Creating..."
           USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAYUSER\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
           QUAYPASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
 

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -35,11 +35,17 @@ data:
       COUNT=$(oc get --ignore-not-found=true secret $SECRET_NAME | wc -l) 
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating default user..."
-          # Invoke API and add quay user to the API - initiates API
-          # TODO: Password should come from a Vault (via a Secret)!!
-          JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"{{ .Values.quay.setup.admin.password }}\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
 
-          oc create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN
+          INITPASS=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo ''  )
+
+          echo "[INFO] Destroy any previous secrets ..."
+          oc delete --ignore-not-found=true secret -n quay-enterprise quay-user
+          oc delete --ignore-not-found=true secret -n openshift-operators quay-pull-secret  
+
+          # Invoke API and add quay user to the API - initiates API
+          JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"$INITPASS\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
+
+          oc create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN --from-literal=password=$INITPASS
           echo "quay-init-token created"
       fi
       
@@ -48,12 +54,47 @@ data:
 
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
-      
+
+      echo "[INFO] Looking for our superuser ..."
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
+      if [ $COUNT = 0 ]; then
+
+          COUNT=$(oc get --ignore-not-found=true secret quay-user | wc -l) 
+          if [ $COUNT = 1 ]; then
+              BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
+          fi
+          
+          # This call can be used without a token to show that quay is configured
+          COUNT=$(curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
+          if [ $COUNT = 1 ]; then
+              echo "Bearer token has expired"
+              exit 0
+          fi
+          
+          echo "[INFO] Creating..."
+          USER=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
+
+          QUAY_PASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
+          BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
+
+          echo "[INFO] Creating a secret with user/password ..."
+          oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USER" --from-literal=basic="$BASE64AUTH"
+
+          echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
+
+          # https://access.redhat.com/solutions/5462311
+          # Requires CLIENTID to be added to DIRECT_OAUTH_CLIENTID_WHITELIST for this to work
+          # If it worked, we could create a new OAuth token when the original one expires after 150min
+          ####
+          # CLIENTID=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | sed -e 's/{/\n/g' | grep "\"name\": \"$APPLICATION\"" | sed -e 's/,/\n/g' | grep client_id | awk '{print $2}' | sed 's/"//g')
+          # curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
+      fi
+
       echo "[INFO] Looking for initial organization ..."
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
-        # Email cannot be shared with the initial user?  
+        # Email cannot be shared with the initial user
         curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
 
@@ -65,30 +106,12 @@ data:
         echo "[INFO] Creating..."
         curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
       fi
-      
+
       echo "[INFO] Looking for initial repo ..."
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
-      fi
-
-      echo "[INFO] Looking for our superuser ..."
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
-      if [ $COUNT = 0 ]; then
-          echo "[INFO] Creating..."
-          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
-          QUAY_PASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
-
-          echo "[INFO] Destroy any previous secrets ..."
-          oc delete --ignore-not-found=true secret -n quay-enterprise quay-user
-          oc delete --ignore-not-found=true secret -n openshift-operators quay-pull-secret  
-
-          echo "[INFO] Creating a secret with user/password ..."
-          oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USERTOKEN"
-
-          BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
-          echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
+          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"  
       fi
 
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
@@ -102,5 +125,6 @@ data:
           echo "[INFO] Give $QUAY_USER admin rights to the repo"
           curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'
       fi
+
 
       echo "[INFO] Job finished"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -50,13 +50,20 @@ data:
         curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"org+$QUAYEMAIL\" }"
       fi
 
+      APPLICATION=automation
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/applications | grep $APPLICATION | wc -l)
+      if [ $COUNT = 0 ]; then
+        echo "[INFO] Create $APPLICATION application"
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/applications --data "{\"name\": \"$QUAYORG-automation\", \"description\": \"automation app\" }"
+      fi
+      
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
             echo "[INFO] Creating a repo ..."
             curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data "{\"namespace\":\"$QUAYORG\", \"repository\":\"$QUAYREPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
       fi
 
-      COUNT=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating a superuser ..."
           USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAYUSER\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
@@ -66,7 +73,7 @@ data:
           oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USERTOKEN"
 
           BASE64AUTH=`echo $QUAYUSER:$QUAYPASSWORD | base64 -w0`
-          echo -e "{  \"auths\": {    \"$QUAYHOST\": {    \"auth\": \"$BASE64AUTH\"    }  }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
+          echo -e "{ \"auths\": { \"$QUAYHOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
       fi
 
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/team/owners/members | grep "name\": \"$QUAYUSER\"" | wc -l)

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -12,17 +12,32 @@ data:
 
       function quay_cmd() {
           DATA='{}'
-          if [ ! -z "$3" ]; then
-              DATA=$3
+          if [ ! -z "$4" ]; then
+              DATA=$4
           fi
-          # Avoid logging the token for security reasons, DATA may contain sensitive info though :-/
-          echo "[INFO] $1 $2 --data $DATA" 1>&2
-          curl -X $1 $CURL_OPTS -H 'Content-Type: application/json'  -H "Authorization: Bearer $TOKEN" $QUAY_HOST$2 --data "$DATA"
+          echo "[INFO] $2 $3 --data $DATA ($1)" 1>&2
+          AUTH="Fake: dummy"
+          if [ $1 = "Basic" ]; then
+              COUNT=$(oc -n $QUAY_NAMESPACE get --ignore-not-found=true secret $QUAY_USER_SECRET | wc -l) 
+              if [ $COUNT -gt 1 ]; then
+                  BASIC=$(oc -n $QUAY_NAMESPACE --ignore-not-found=true extract secret/$QUAY_USER_SECRET --keys=basic --to=-)
+              fi
+              AUTH="Authorization: Basic $BASIC"
+
+          elif [ $1 = "Bearer" ]; then
+              AUTH="Authorization: Bearer $TOKEN"
+          fi
+          curl -X $2 $CURL_OPTS -H 'Content-Type: application/json'  -H "$AUTH" $QUAY_HOST$3 --data "$DATA"
+          echo "[INFO] Success" 1>&2
       }
 
       CURL_OPTS="-fsk"
+      QUAY_USER_SECRET=quay-user
 
       env | grep QUAY | grep -v QUAY_REGISTRY
+      if [ -z "$QUAY_NAMESPACE" ]; then
+          QUAY_NAMESPACE={{ .Values.quay.namespace }}
+      fi
       if [ -z "$QUAY_HOST" ]; then
           QUAY_HOST="https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}"
       fi
@@ -42,42 +57,41 @@ data:
           QUAY_REPO={{ .Values.quay.setup.repo }}
       fi
 
-      #  '-n quay-enterprise' is implied
       echo "[INFO] Looking for initial token ..."
       SECRET_NAME=quay-init-token
-      COUNT=$(oc get --ignore-not-found=true -n quay-enterprise secret $SECRET_NAME | wc -l) 
+      COUNT=$(oc -n $QUAY_NAMESPACE get --ignore-not-found=true secret $SECRET_NAME | wc -l) 
       if [ $COUNT = 0 ]; then
           INITPASS=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo ''  )
 
           echo "[INFO] Destroy any previous secrets ..."
-          oc delete --ignore-not-found=true secret -n quay-enterprise quay-user
-          oc delete --ignore-not-found=true secret -n openshift-operators quay-pull-secret  
+          oc -n $QUAY_NAMESPACE delete --ignore-not-found=true secret $QUAY_USER_SECRET
+          oc -n openshift-operators delete --ignore-not-found=true secret quay-pull-secret  
 
           # Invoke API and add quay user to the API - initiates API
           echo "[INFO] Creating default user..."
-          JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"$INITPASS\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
+          JSONTOKEN=$(quay_cmd None POST /api/v1/user/initialize "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"$INITPASS\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
 
           echo "[INFO] Creating $SECRET_NAME ..."
-          oc -n quay-enterprise create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN --from-literal=password=$INITPASS
+          oc -n $QUAY_NAMESPACE create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN --from-literal=password=$INITPASS
       fi
       
-      TOKEN=$(oc -n quay-enterprise extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
+      TOKEN=$(oc -n $QUAY_NAMESPACE extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
 
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
 
       echo "[INFO] Checking our bearer token is still valid ..."
-      COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
+      COUNT=$(quay_cmd Bearer GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then
           # Either the super user doesn't exist, or the token is invalid... determine which...
-          COUNT=$(oc -n quay-enterprise get --ignore-not-found=true secret quay-user | wc -l) 
+          COUNT=$(oc -n $QUAY_NAMESPACE get --ignore-not-found=true secret $QUAY_USER_SECRET | wc -l) 
           if [ $COUNT -gt 1 ]; then
-              BASIC=$(oc -n quay-enterprise extract secret/quay-user --keys=basic --to=-)
+              BASIC=$(oc -n $QUAY_NAMESPACE extract secret/$QUAY_USER_SECRET --keys=basic --to=-)
           
               # This call can be used without a token to show that quay is configured
-              COUNT=$(curl -X GET $CURL_OPTS -H 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
+              COUNT=$(quay_cmd Basic GET /api/v1/organization/$QUAY_ORG | wc -l)
               if [ $COUNT -gt 0 ]; then
-                  # We found the quay-user secret, with valid basic auth details, and the organization... conclude the bearer token has expired (150min lifetime)
+                  # We found the $QUAY_USER_SECRET secret, with valid basic auth details, and the organization... conclude the bearer token has expired (150min lifetime)
                   echo "Bearer token has expired"
                   exit 0
               fi
@@ -85,69 +99,66 @@ data:
       fi
 
       echo "[INFO] Looking for our superuser ..."
-      # Org must exist first?  Makes no sense, but it seems to be true
-      COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
+      COUNT=$(quay_cmd Bearer GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then    
           echo "[INFO] Creating $QUAY_USER user ..."
-          RESPONSE=$(quay_cmd POST /api/v1/superuser/users/ "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
+          RESPONSE=$(quay_cmd Bearer POST /api/v1/superuser/users/ "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
 
           QUAY_PASSWORD=$(echo $RESPONSE | cut -d : -f5 | awk -F\} '{print $1}')
           BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
 
-          echo "[INFO] Creating quay-user secret ..."
-          oc create secret -n quay-enterprise generic quay-user --from-literal=token="$RESPONSE" --from-literal=basic="$BASE64AUTH"
+          echo "[INFO] Creating $QUAY_USER_SECRET secret ..."
+          oc -n $QUAY_NAMESPACE create secret generic $QUAY_USER_SECRET --from-literal=token="$RESPONSE" --from-literal=basic="$BASE64AUTH"
 
           echo "[INFO] Creating quay-pull-secret ..."
-          echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
+          echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc -n openshift-operators create secret generic quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
 
           # https://access.redhat.com/solutions/5462311
           # Requires CLIENTID to be added to DIRECT_OAUTH_CLIENTID_WHITELIST for this to work
           # If it worked, we could create a new OAuth token when the original one expires after 150min
           ####
-          # CLIENTID=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/applications | sed -e 's/{/\n/g' | grep "\"name\": \"$APPLICATION\"" | sed -e 's/,/\n/g' | grep client_id | awk '{print $2}' | sed 's/"//g')
+          # CLIENTID=$(quay_cmd Bearer GET /api/v1/organization/$QUAY_ORG/applications | sed -e 's/{/\n/g' | grep "\"name\": \"$APPLICATION\"" | sed -e 's/,/\n/g' | grep client_id | awk '{print $2}' | sed 's/"//g')
           # quay_cmd PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
       fi
 
       echo "[INFO] Looking for initial organization ..."
-      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
+      COUNT=$(quay_cmd Bearer GET /api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating $QUAY_ORG org ..."
         # Email cannot be shared with the initial user
-        quay_cmd POST /api/v1/organization/  "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+        quay_cmd Bearer POST /api/v1/organization/ "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+        quay_cmd Basic GET /api/v1/organization/$QUAY_ORG  
       fi
-      
-      BASIC=$(oc -n quay-enterprise extract secret/quay-user --keys=basic --to=-)
-      curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG  
-      
+
       echo "[INFO] Looking for org application ..."
       # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token
       # If there was a programatic way to do it here, we could avoid the problem with the bearer token expiring after 150min
       APPLICATION=automation
-      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
+      COUNT=$(quay_cmd Bearer GET /api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
       if [ $COUNT = 0 ]; then
-        echo "[INFO] Creating..."
-        quay_cmd POST /api/v1/organization/$QUAY_ORG/applications "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
+        echo "[INFO] Creating $APPLICATION application..."
+        quay_cmd Bearer POST /api/v1/organization/$QUAY_ORG/applications "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
       fi
 
       echo "[INFO] Looking for initial repo ..."
-      COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
+      COUNT=$(quay_cmd Bearer GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating $QUAY_REPO repo..."
-          quay_cmd POST /api/v1/repository "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"  
+          quay_cmd Bearer POST /api/v1/repository "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"  
       fi
 
       echo "[INFO] Looking for $QUAY_ORG members ..."
-      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
+      COUNT=$(quay_cmd Bearer GET /api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Associating $QUAY_USER with $QUAY_ORG ..."
-          quay_cmd PUT /api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER '{}'
+          quay_cmd Bearer PUT /api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER '{}'
       fi
 
       echo "[INFO] Looking for $QUAY_REPO admins ..."
-      COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
+      COUNT=$(quay_cmd Bearer GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Give $QUAY_USER admin rights to the repo ..."
-          quay_cmd PUT /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER '{ "role": "admin"}'
+          quay_cmd Bearer PUT /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER '{ "role": "admin"}'
       fi
 
       echo "[INFO] Job finished"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -44,40 +44,40 @@ data:
       fi
       
       TOKEN=$(oc extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
-      CURL_OPTS="--fail -k  --header 'Content-Type: application/json'"
+      CURL_OPTS="--fail -k"
 
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
       
       echo "[INFO] Looking for initial organization ..."
-      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
         # Email cannot be shared with the initial user?  
-        curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
 
       echo "[INFO] Looking for org application ..."
       # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
       APPLICATION=automation
-      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
-        curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
       fi
       
       echo "[INFO] Looking for initial repo ..."
-      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
+          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
       fi
 
       echo "[INFO] Looking for our superuser ..."
-      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          USERTOKEN=$(curl -X POST $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
+          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
           QUAY_PASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
 
           echo "[INFO] Creating a secret with user/password ..."
@@ -87,16 +87,16 @@ data:
           echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Associating $QUAY_USER with $QUAY_ORG"
-          curl -X PUT $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER --data '{}'
+          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER --data '{}'
       fi
 
-      COUNT=$(curl -X GET $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
+      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Give $QUAY_USER admin rights to the repo"
-          curl -X PUT $CURL_OPTS -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'
+          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'
       fi
 
       echo "[INFO] Job finished"

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -80,6 +80,10 @@ data:
           USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
           QUAY_PASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
 
+          echo "[INFO] Destroy any previous secrets ..."
+          oc delete --ignore-not-found=true secret -n quay-enterprise quay-user
+          oc delete --ignore-not-found=true secret -n openshift-operators quay-pull-secret  
+
           echo "[INFO] Creating a secret with user/password ..."
           oc create secret -n quay-enterprise generic quay-user --from-literal=token="$USERTOKEN"
 

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -15,7 +15,7 @@ data:
           if [ ! -z "$4" ]; then
               DATA=$4
           fi
-          echo "[INFO] $2 $3 --data $DATA ($1)" 1>&2
+          echo "[$1] $2 $3 --data $DATA" 1>&2
           AUTH="Fake: dummy"
           if [ $1 = "Basic" ]; then
               COUNT=$(oc -n $QUAY_NAMESPACE get --ignore-not-found=true secret $QUAY_USER_SECRET | wc -l) 

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 data:
   create-quaye-pull-secret.sh: |
-    #!/bin/bash
+    #!/bin/bash -ex
     echo "[INFO] QUAYORG: $QUAYORG QUAYUSER: $QUAYUSER"
     oc get secret quay-temp-token
     if [ $? -ne 0 ]; then
@@ -39,6 +39,7 @@ data:
         echo "[INFO] Repo created"
       else 
         echo "[WARNING] Could not create repo"
+        exit 2
       fi
       echo "[INFO] Creating a user ..."
       USERTOKEN=$(curl -X POST -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/superuser/users/ -H "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' --data '{ "username": "{{ .Values.devel.quayuser }}", "email": "{{ .Values.devel.quayuseremail }}", "access_token": true}')
@@ -47,6 +48,7 @@ data:
         echo "[INFO] User created"
       else 
         echo "[WARNING] Could not create User"
+        exit 2
       fi
       QUAYPASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
       echo "[INFO] Creating a secret with user/password ..."
@@ -55,6 +57,7 @@ data:
         echo "[INFO] User secret created"
       else 
         echo "[WARNING] Could not create secret quay-user."
+        exit 2
       fi
       echo "[INFO] Associating $QUAYUSER with $QUAYORG"
       OUTPUT=$(curl -X PUT -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/organization/$QUAYORG/team/owners/members/$QUAYUSER -H "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' --data '{}')

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -84,17 +84,13 @@ data:
       COUNT=$(quay_cmd Bearer GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then
           # Either the super user doesn't exist, or the token is invalid... determine which...
-          COUNT=$(oc -n $QUAY_NAMESPACE get --ignore-not-found=true secret $QUAY_USER_SECRET | wc -l) 
-          if [ $COUNT -gt 1 ]; then
-              BASIC=$(oc -n $QUAY_NAMESPACE extract secret/$QUAY_USER_SECRET --keys=basic --to=-)
-          
-              # This call can be used without a token to show that quay is configured
-              COUNT=$(quay_cmd Basic GET /api/v1/organization/$QUAY_ORG | wc -l)
-              if [ $COUNT -gt 0 ]; then
-                  # We found the $QUAY_USER_SECRET secret, with valid basic auth details, and the organization... conclude the bearer token has expired (150min lifetime)
-                  echo "Bearer token has expired"
-                  exit 0
-              fi
+
+          COUNT=$(quay_cmd Basic GET /api/v1/organization/$QUAY_ORG | wc -l)
+          if [ $COUNT -gt 0 ]; then
+              # We found the $QUAY_USER_SECRET secret, with valid basic auth details, and used it to obtain the previously created organization...
+              # Conclude the bearer token has expired (150min lifetime)
+              echo "Bearer token has expired"
+              exit 0
           fi
       fi
 

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -32,7 +32,7 @@ data:
           # TODO: Password should come from a Vault (via a Secret)!!
           JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"{{ .Values.quay.setup.admin.password }}\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
 
-          oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
+          oc create secret generic quay-init-token --from-literal=token=$JSONTOKEN
           echo "quay-init-token created"
       fi
       

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -45,7 +45,7 @@ data:
       #  '-n quay-enterprise' is implied
       echo "[INFO] Looking for initial token ..."
       SECRET_NAME=quay-init-token
-      COUNT=$(oc get --ignore-not-found=true secret $SECRET_NAME | wc -l) 
+      COUNT=$(oc get --ignore-not-found=true -n quay-enterprise secret $SECRET_NAME | wc -l) 
       if [ $COUNT = 0 ]; then
           INITPASS=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 20 ; echo ''  )
 
@@ -58,10 +58,10 @@ data:
           JSONTOKEN=$(curl -X POST -k  $QUAY_HOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"{{ .Values.quay.setup.admin.name }}\", \"password\":\"$INITPASS\", \"email\": \"{{ .Values.quay.setup.admin.email }}\", \"access_token\": true}")
 
           echo "[INFO] Creating $SECRET_NAME ..."
-          oc create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN --from-literal=password=$INITPASS
+          oc -n quay-enterprise create secret generic $SECRET_NAME --from-literal=token=$JSONTOKEN --from-literal=password=$INITPASS
       fi
       
-      TOKEN=$(oc extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
+      TOKEN=$(oc -n quay-enterprise extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
 
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
@@ -70,9 +70,9 @@ data:
       COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
       if [ $COUNT = 0 ]; then
           # Either the super user doesn't exist, or the token is invalid... determine which...
-          COUNT=$(oc get --ignore-not-found=true secret quay-user | wc -l) 
+          COUNT=$(oc -n quay-enterprise get --ignore-not-found=true secret quay-user | wc -l) 
           if [ $COUNT -gt 1 ]; then
-              BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
+              BASIC=$(oc -n quay-enterprise extract secret/quay-user --keys=basic --to=-)
           
               # This call can be used without a token to show that quay is configured
               COUNT=$(curl -X GET $CURL_OPTS -H 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
@@ -82,14 +82,6 @@ data:
                   exit 0
               fi
           fi
-      fi
-
-      echo "[INFO] Looking for initial organization ..."
-      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
-      if [ $COUNT = 0 ]; then
-        echo "[INFO] Creating $QUAY_ORG org ..."
-        # Email cannot be shared with the initial user
-        quay_cmd POST /api/v1/organization/  "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
 
       echo "[INFO] Looking for our superuser ..."
@@ -116,7 +108,15 @@ data:
           # quay_cmd PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
       fi
 
-      BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
+      echo "[INFO] Looking for initial organization ..."
+      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
+      if [ $COUNT = 0 ]; then
+        echo "[INFO] Creating $QUAY_ORG org ..."
+        # Email cannot be shared with the initial user
+        quay_cmd POST /api/v1/organization/  "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+      fi
+      
+      BASIC=$(oc -n quay-enterprise extract secret/quay-user --keys=basic --to=-)
       curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG  
       
       echo "[INFO] Looking for org application ..."

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -32,7 +32,7 @@ data:
           echo "[INFO] Creating Quay default user..."
           # Invoke API and add quay user to the API - initiates API
           # TODO: Password should come from a Vault (via a Secret)!!
-          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data '{ "username": "$QUAYUSER", "password":"{{ .Values.global.quay.password }}", "email": "$QUAYEMAIL", "access_token": true}')
+          JSONTOKEN=$(curl -X POST -k  $QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"$QUAYUSER\", \"password\":\"{{ .Values.global.quay.password }}\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
 
           oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
           echo "quay-temp-token created"
@@ -44,7 +44,7 @@ data:
       COUNT=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ | grep $QUAYUSER | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating a superuser ..."
-          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ --data '{ "username": "$QUAYUSER", "email": "$QUAYEMAIL", "access_token": true}')
+          USERTOKEN=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAYUSER\", \"email\": \"$QUAYEMAIL\", \"access_token\": true}")
           QUAYPASSWORD=$(echo $USERTOKEN | cut -d : -f5 | awk -F\} '{print $1}')
 
           echo "[INFO] Creating a secret with user/password ..."
@@ -59,13 +59,14 @@ data:
         # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
         # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
         echo "[INFO] Create organization $QUAYORG"
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data '{"name": "$QUAYORG", "email": "$QUAYEMAIL" }'
+        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/ --data "{\"name\": \"$QUAYORG\", \"email\": \"$QUAYEMAIL\" }"
       fi
+
 
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository/$QUAYORG/$QUAYREPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
             echo "[INFO] Creating a repo ..."
-            curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data '{"namespace":"$QUAYORG", "repository":"$QUAYREPO", "visibility":"public", "description":"Development Repo", "repo_kind":"image"}'
+            curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/repository --data "{\"namespace\":\"$QUAYORG\", \"repository\":\"$QUAYREPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"
       fi
             
       COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAYHOST/api/v1/organization/$QUAYORG/team/owners/members | grep "name\": \"$QUAYUSER\"" | wc -l)

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -15,8 +15,10 @@ data:
           if [ ! -z "$3" ]; then
               DATA=$3
           fi
-          curl -X $1 --fail -k --header 'Content-Type: application/json'  -H "Authorization: Bearer $TOKEN" $QUAY_HOST$2 --data "$DATA"
+          curl -X $1 $CURL_OPTS -H 'Content-Type: application/json'  -H "Authorization: Bearer $TOKEN" $QUAY_HOST$2 --data "$DATA"
       }
+
+      CURL_OPTS="-fSk"
 
       env | grep QUAY
       if [ -z "$QUAY_HOST" ]; then
@@ -59,10 +61,25 @@ data:
       fi
       
       TOKEN=$(oc extract secret/$SECRET_NAME --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')
-      CURL_OPTS="--fail -k"
 
       # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
       # oc create secret -n openshift-operators generic quay-integration --from-literal=token=$TOKEN
+
+      echo "[INFO] Checking our bearer token is still valid ..."
+      COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
+      if [ $COUNT = 0 ]; then    
+          COUNT=$(oc get --ignore-not-found=true secret quay-user | wc -l) 
+          if [ $COUNT -gt 1 ]; then
+              BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
+          
+              # This call can be used without a token to show that quay is configured
+              COUNT=$(curl -X GET $CURL_OPTS -H 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
+              if [ $COUNT -gt 0 ]; then
+                  echo "Bearer token has expired"
+                  exit 0
+              fi
+          fi
+      fi      
 
       echo "[INFO] Looking for initial organization ..."
       COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG | grep -v not_found | wc -l)
@@ -83,20 +100,7 @@ data:
 
       echo "[INFO] Looking for our superuser ..."
       COUNT=$(quay_cmd GET /api/v1/superuser/users/ | grep \"$QUAY_USER\" | wc -l)
-      if [ $COUNT = 0 ]; then
-
-          COUNT=$(oc get --ignore-not-found=true secret quay-user | wc -l) 
-          if [ $COUNT -gt 1 ]; then
-              BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
-          fi
-          
-          # This call can be used without a token to show that quay is configured
-          COUNT=$(quay_cmd GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
-          if [ $COUNT = 1 ]; then
-              echo "Bearer token has expired"
-              exit 0
-          fi
-          
+      if [ $COUNT = 0 ]; then    
           echo "[INFO] Creating..."
           RESPONSE=$(quay_cmd POST /api/v1/superuser/users/ "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
 
@@ -110,6 +114,7 @@ data:
 
           BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
           curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG
+          
           # https://access.redhat.com/solutions/5462311
           # Requires CLIENTID to be added to DIRECT_OAUTH_CLIENTID_WHITELIST for this to work
           # If it worked, we could create a new OAuth token when the original one expires after 150min

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -10,15 +10,15 @@ data:
   create-quaye-pull-secret.sh: |
     #!/bin/bash -ex
     echo "[INFO] QUAYORG: $QUAYORG QUAYUSER: $QUAYUSER"
-    oc get secret quay-temp-token
-    if [ $? -ne 0 ]; then
-      echo "[INFO] Quay default user not created. Creating ..."  
-      # Invoke API and add quay user to the API - initiates API
-      JSONTOKEN=$(curl -X POST -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/user/initialize --header 'Content-Type: application/json' --data '{ "username": "{{ .Values.global.quay.account }}", "password":"{{ .Values.global.quay.password }}", "email": "$QUAYEMAIL", "access_token": true}')
-      echo "[INFO] TOKEN: $JSONTOKEN"
-      oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
-    fi
+    oc delete --ignore-not-found=true secret quay-temp-token
+
+    echo "[INFO] Creating Quay default user not created..."  
+    # Invoke API and add quay user to the API - initiates API
+    JSONTOKEN=$(curl -X POST -k  https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/api/v1/user/initialize --header 'Content-Type: application/json' --data '{ "username": "{{ .Values.global.quay.account }}", "password":"{{ .Values.global.quay.password }}", "email": "$QUAYEMAIL", "access_token": true}')
+    echo "[INFO] TOKEN: $JSONTOKEN"
+    oc create secret generic quay-temp-token --from-literal=token=$JSONTOKEN
     echo "quay-temp-token created"
+
     echo "[INFO] Secret quay-integration not created. Creating ..."  
     # Now extract the token and store in the Quay Integration secret in openshift-operators namespace
     TOKEN=$(oc extract secret/quay-temp-token --keys=token --to=- | grep access_token | cut -d : -f2 | awk -F\" '{print $2}')

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -82,6 +82,8 @@ data:
 
           echo -e "{ \"auths\": { \"$QUAY_HOST\": { \"auth\": \"$BASE64AUTH\" } }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson
 
+          BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
+          COUNT=$(curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
           # https://access.redhat.com/solutions/5462311
           # Requires CLIENTID to be added to DIRECT_OAUTH_CLIENTID_WHITELIST for this to work
           # If it worked, we could create a new OAuth token when the original one expires after 150min

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -100,7 +100,7 @@ data:
           echo "[INFO] Creating $QUAY_USER user ..."
           RESPONSE=$(quay_cmd Bearer POST /api/v1/superuser/users/ "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
 
-          QUAY_PASSWORD=$(echo $RESPONSE | cut -d : -f5 | awk -F\} '{print $1}')
+          QUAY_PASSWORD=$(echo $RESPONSE | tr ',' '\n' | grep '"password"' | cut -d \" -f 4)
           BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
 
           echo "[INFO] Creating $QUAY_USER_SECRET secret ..."

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -60,7 +60,7 @@ data:
       if [ $COUNT = 0 ]; then
 
           COUNT=$(oc get --ignore-not-found=true secret quay-user | wc -l) 
-          if [ $COUNT = 1 ]; then
+          if [ $COUNT -gt 1 ]; then
               BASIC=$(oc extract secret/quay-user --keys=basic --to=-)
           fi
           

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -69,17 +69,16 @@ data:
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
         # Email cannot be shared with the initial user
-        quay_cmd POST /api/v1/organization/$QUAY_ORG  "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
-        #curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/ --data "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
+        quay_cmd POST /api/v1/organization/  "{\"name\": \"$QUAY_ORG\", \"email\": \"$QUAY_ORG_EMAIL\" }"
       fi
       
       echo "[INFO] Looking for org application ..."
       # The only way to get another OAuth token is to go to: Organization -> Applications -> {app} -> Generate Token 
       APPLICATION=automation
-      COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
+      COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/applications | grep $APPLICATION | wc -l)
       if [ $COUNT = 0 ]; then
         echo "[INFO] Creating..."
-        curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications --data "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
+        quay_cmd POST /api/v1/organization/$QUAY_ORG/applications "{\"name\": \"$QUAY_ORG-automation\", \"description\": \"automation app\" }"
       fi
 
       echo "[INFO] Looking for our superuser ..."
@@ -92,14 +91,14 @@ data:
           fi
           
           # This call can be used without a token to show that quay is configured
-          COUNT=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
+          COUNT=$(quay_cmd GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASIC" $QUAY_HOST/api/v1/organization/$QUAY_ORG | wc -l)
           if [ $COUNT = 1 ]; then
               echo "Bearer token has expired"
               exit 0
           fi
           
           echo "[INFO] Creating..."
-          RESPONSE=$(curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/superuser/users/ --data "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
+          RESPONSE=$(quay_cmd POST /api/v1/superuser/users/ "{ \"username\": \"$QUAY_USER\", \"email\": \"$QUAY_USER_EMAIL\", \"access_token\": true}")
 
           QUAY_PASSWORD=$(echo $RESPONSE | cut -d : -f5 | awk -F\} '{print $1}')
           BASE64AUTH=`echo $QUAY_USER:$QUAY_PASSWORD | base64 -w0`
@@ -115,27 +114,27 @@ data:
           # Requires CLIENTID to be added to DIRECT_OAUTH_CLIENTID_WHITELIST for this to work
           # If it worked, we could create a new OAuth token when the original one expires after 150min
           ####
-          # CLIENTID=$(curl -X GET $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/applications | sed -e 's/{/\n/g' | grep "\"name\": \"$APPLICATION\"" | sed -e 's/,/\n/g' | grep client_id | awk '{print $2}' | sed 's/"//g')
-          # curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
+          # CLIENTID=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/applications | sed -e 's/{/\n/g' | grep "\"name\": \"$APPLICATION\"" | sed -e 's/,/\n/g' | grep client_id | awk '{print $2}' | sed 's/"//g')
+          # quay_cmd PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Basic $BASE64AUTH" $QUAY_HOST/oauth/authorize?response_type=token&client_id=$CLIENTID&scope=org:admin%20repo:admin%20repo:create%20repo:read%20repo:write%20super:user%20user:admin%20user:read&redirect_uri=$QUAY_HOST%2Foauth%2Flocalapp
       fi
 
       echo "[INFO] Looking for initial repo ..."
       COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO | grep -v not_found | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Creating..."
-          curl -X POST $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository --data "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"  
+          quay_cmd POST /api/v1/repository "{\"namespace\":\"$QUAY_ORG\", \"repository\":\"$QUAY_REPO\", \"visibility\":\"public\", \"description\":\"Development Repo\", \"repo_kind\":\"image\"}"  
       fi
 
       COUNT=$(quay_cmd GET /api/v1/organization/$QUAY_ORG/team/owners/members | grep "name\": \"$QUAY_USER\"" | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Associating $QUAY_USER with $QUAY_ORG"
-          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER --data '{}'
+          quay_cmd PUT /api/v1/organization/$QUAY_ORG/team/owners/members/$QUAY_USER '{}'
       fi
 
       COUNT=$(quay_cmd GET /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER | grep '"role": "admin"' | wc -l)
       if [ $COUNT = 0 ]; then
           echo "[INFO] Give $QUAY_USER admin rights to the repo"
-          curl -X PUT $CURL_OPTS --header 'Content-Type: application/json' -H "Authorization: Bearer $TOKEN" $QUAY_HOST/api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER --data '{ "role": "admin"}'
+          quay_cmd PUT /api/v1/repository/$QUAY_ORG/$QUAY_REPO/permissions/user/$QUAY_USER '{ "role": "admin"}'
       fi
 
 

--- a/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/cm-create-quaye-pull-secret.yaml
@@ -72,7 +72,7 @@ data:
         echo "[ERROR] Could not $QUAYUSER admin rights"
         exit 2
       fi
-      BASE64AUTH=`echo $QUAYUSER:$QUAYPASSWORD | base64`
+      BASE64AUTH=`echo $QUAYUSER:$QUAYPASSWORD | base64 -w0`
       echo "[INFO] BASE64AUTH=$BASE64AUTH"
       echo -e "{\n  \"auths\": {\n    \"https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}\": {\n    \"auth\": \"$BASE64AUTH\"\n    }\n  }\n}"
       echo -e "{  \"auths\": {    \"https://quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}\": {    \"auth\": \"$BASE64AUTH\"    }  }}" | oc create secret generic --namespace=openshift-operators quay-pull-secret --from-file=.dockerconfigjson=/dev/stdin --type=kubernetes.io/dockerconfigjson

--- a/charts/hub/quay/templates/quayRegistry/job-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/job-create-quaye-pull-secret.yaml
@@ -13,12 +13,16 @@ spec:
       containers: 
       - image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
         env:
-        - name: QUAYEMAIL
-          value: "{{ .Values.global.quay.email }}"
-        - name: QUAYORG
-          value: "{{ .Values.devel.quayorg }}"
-        - name: QUAYUSER
-          value: "{{ .Values.devel.quayuser }}"
+        - name: QUAY_ORG
+          value: "{{ .Values.quay.setup.org.name }}"
+        - name: QUAY_ORG_EMAIL
+          value: "{{ .Values.quay.setup.org.email }}"
+        - name: QUAY_USER
+          value: "{{ .Values.quay.setup.user.name }}"
+        - name: QUAY_USER_EMAIL
+          value: "{{ .Values.quay.setup.user.email }}"
+        - name: QUAY_REPO
+          value: "{{ .Values.quay.setup.repo }}"
         command:
         - /bin/bash
         - -c

--- a/charts/hub/quay/templates/quayRegistry/job-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/job-create-quaye-pull-secret.yaml
@@ -13,14 +13,6 @@ spec:
       containers: 
       - image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
         env:
-        - name: QUAY_ORG
-          value: "{{ .Values.quay.setup.org.name }}"
-        - name: QUAY_ORG_EMAIL
-          value: "{{ .Values.quay.setup.org.email }}"
-        - name: QUAY_USER
-          value: "{{ .Values.quay.setup.user.name }}"
-        - name: QUAY_USER_EMAIL
-          value: "{{ .Values.quay.setup.user.email }}"
         - name: QUAY_REPO
           value: "{{ .Values.quay.setup.repo }}"
         command:

--- a/charts/hub/quay/templates/quayRegistry/job-create-quaye-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/job-create-quaye-pull-secret.yaml
@@ -14,7 +14,7 @@ spec:
       - image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
         env:
         - name: QUAY_REPO
-          value: "{{ .Values.quay.setup.repo }}"
+          value: "{{ .Values.global.quay.repo }}"
         command:
         - /bin/bash
         - -c

--- a/charts/hub/quay/templates/quayRegistry/job-wait-on-quay-app-deploy.yaml
+++ b/charts/hub/quay/templates/quayRegistry/job-wait-on-quay-app-deploy.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/sync-wave: "6"
+  name: wait-for-quay-app-deploy
+  namespace: {{ .Values.quay.namespace }}
+spec:
+  template:
+    spec:
+      containers: 
+      - image: {{ .Values.job.image }}
+        command:
+        - /bin/bash
+        - -c
+        - |
+          # wait for the operator QuayRegistry CR to be available
+          oc wait QuayRegistry quay-registry --for=condition=Available=true
+        name: wait-for-quay-app
+      dnsPolicy: ClusterFirst
+      activeDeadlineSeconds: 900
+      restartPolicy: Never
+      serviceAccountName: quay-admin-sa
+      terminationGracePeriodSeconds: 60

--- a/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
+++ b/charts/hub/quay/templates/quayRegistry/policy-quay-pull-secret.yaml
@@ -35,7 +35,7 @@ spec:
                   namespace: openshift-operators  # consider changing this to devsecops-ci
                 apiVersion: v1
                 data:
-                  token: '{{ `{{hub fromSecret "openshift-operators" "quay-pull-secret" ".dockerconfigjson" hub}}` }}'
+                  .dockerconfigjson: '{{ `{{hub fromSecret "openshift-operators" "quay-pull-secret" ".dockerconfigjson" hub}}` }}'
             - complianceType: mustonlyhave
               objectDefinition:
                 kind: Secret
@@ -45,7 +45,7 @@ spec:
                   namespace: devsecops-ci
                 apiVersion: v1
                 data:
-                  token: '{{ `{{hub fromSecret "openshift-operators" "quay-pull-secret" ".dockerconfigjson" hub}}` }}'
+                  .dockerconfigjson: '{{ `{{hub fromSecret "openshift-operators" "quay-pull-secret" ".dockerconfigjson" hub}}` }}'
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/charts/hub/quay/templates/rbac/quay-admin-role.yaml
+++ b/charts/hub/quay/templates/rbac/quay-admin-role.yaml
@@ -13,6 +13,7 @@ rules:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -21,4 +22,5 @@ rules:
       - get
       - create
       - list
+      - delete
 

--- a/charts/hub/quay/templates/secret/secret.yaml
+++ b/charts/hub/quay/templates/secret/secret.yaml
@@ -11,7 +11,7 @@ stringData:
     FEATURE_USER_INITIALIZE: true
     BROWSER_API_CALLS_XHR_ONLY: false
     SUPER_USERS:
-    - {{ .Values.quay.adminuser }}
+    - {{ .Values.quay.setup.admin.name }}
     FEATURE_USER_CREATION: true
     ALLOW_PULLS_WITHOUT_STRICT_LOGGING: false
     AUTHENTICATION_TYPE: Database

--- a/charts/hub/quay/values.yaml
+++ b/charts/hub/quay/values.yaml
@@ -28,16 +28,17 @@ quay:
     name: quay-init-config-bundle-secret
   setup:
     admin:
-      name: quay
-      # Password SHOULD NOT be here!
-      password: quayadmin123
+      # Generated password is saved to the 'quay-init-token' secret in the configured namespace  
+      name: quayadmin
       email: quayadmin@example.com
     org:
       name: devel
       email: devel@myorg.com
     user:
-      name: admin
-      email: admin@myorg.com
+      # Generated password is saved to the 'quay-user' secret in the configured namespace
+      # The API only allows the creation of superusers
+      name: developer1
+      email: developer1@myorg.com
     repo: example
 
 job:

--- a/charts/hub/quay/values.yaml
+++ b/charts/hub/quay/values.yaml
@@ -36,8 +36,8 @@ quay:
       name: devel
       email: devel@myorg.com
     user:
-      name: developer1
-      email: developer1@myorg.com
+      name: admin
+      email: admin@myorg.com
     repo: example
 
 job:

--- a/charts/hub/quay/values.yaml
+++ b/charts/hub/quay/values.yaml
@@ -1,6 +1,5 @@
 quay:
   namespace: quay-enterprise
-  adminuser: quayadmin
   component:
     - name: clair
       managed: true
@@ -29,7 +28,7 @@ quay:
     name: quay-init-config-bundle-secret
   setup:
     admin:
-      name: quayadmin
+      name: quay
       # Password SHOULD NOT be here!
       password: quayadmin123
       email: quayadmin@example.com

--- a/charts/hub/quay/values.yaml
+++ b/charts/hub/quay/values.yaml
@@ -31,14 +31,17 @@ quay:
       # Generated password is saved to the 'quay-init-token' secret in the configured namespace  
       name: quayadmin
       email: quayadmin@example.com
-    org:
-      name: devel
-      email: devel@myorg.com
     user:
       # Generated password is saved to the 'quay-user' secret in the configured namespace
       # The API only allows the creation of superusers
       name: developer1
       email: developer1@myorg.com
+
+global:
+  quay:
+    org:
+      name: devel
+      email: devel@myorg.com
     repo: example
 
 job:

--- a/charts/hub/quay/values.yaml
+++ b/charts/hub/quay/values.yaml
@@ -27,6 +27,19 @@ quay:
   configBundleSecret:
     deploy: true
     name: quay-init-config-bundle-secret
+  setup:
+    admin:
+      name: quayadmin
+      # Password SHOULD NOT be here!
+      password: quayadmin123
+      email: quayadmin@example.com
+    org:
+      name: devel
+      email: devel@myorg.com
+    user:
+      name: developer1
+      email: developer1@myorg.com
+    repo: example
 
 job:
   image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -37,6 +50,3 @@ global:
     domain: DOMAIN
 
   quay:
-    account: quayadmin
-    password: quayadmin123
-    email: quayadmin@example.com

--- a/charts/region/pipelines/templates/app-pipeline/pipelines/build-and-sign.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/pipelines/build-and-sign.yaml
@@ -49,7 +49,7 @@ spec:
       name: buildah-to-registry
     params:
       - name: IMAGE
-        value: 'quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/{{ .Values.devel.image }}'
+        value: 'quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/{{ .Values.quay.setup.org.name }}/{{ .Values.quay.setup.repo }}:$(params.github-repo-revision)'
       - name: CONTEXT
         value: '.'
       - name: TLSVERIFY

--- a/charts/region/pipelines/templates/app-pipeline/pipelines/build-and-sign.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/pipelines/build-and-sign.yaml
@@ -49,7 +49,7 @@ spec:
       name: buildah-to-registry
     params:
       - name: IMAGE
-        value: 'quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/{{ .Values.quay.setup.org.name }}/{{ .Values.quay.setup.repo }}:$(params.github-repo-revision)'
+        value: 'quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/{{ .Values.global.quay.org.name }}/{{ .Values.global.quay.repo }}:$(params.github-repo-revision)'
       - name: CONTEXT
         value: '.'
       - name: TLSVERIFY

--- a/charts/region/pipelines/templates/app-pipeline/pipelines/build-and-sign.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/pipelines/build-and-sign.yaml
@@ -49,7 +49,7 @@ spec:
       name: buildah-to-registry
     params:
       - name: IMAGE
-        value: '{{ .Values.devel.image }}'
+        value: 'quay-registry-quay-quay-enterprise.{{ .Values.global.hubClusterDomain }}/{{ .Values.devel.image }}'
       - name: CONTEXT
         value: '.'
       - name: TLSVERIFY

--- a/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
@@ -69,6 +69,7 @@ spec:
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
     script: |
+      set -x
       buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
         $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
@@ -87,6 +88,8 @@ spec:
           name: $(params.QUAY_SECRET)
           key: .dockerconfigjson
     script: |
+      set -x
+      env | grep QUAY
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \

--- a/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
@@ -54,9 +54,8 @@ spec:
   - name: source
 
   volumes:
-  - name: varlibcontainers
-    persistentVolumeClaim:
-      claimName: containers-pvc
+  - emptyDir: {}
+    name: varlibcontainers
 
   results:
   - name: IMAGE_DIGEST
@@ -81,6 +80,8 @@ spec:
   - name: push
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
+    securityContext:
+      privileged: false
     env:
     - name: QUAY_PUSH_SECRET
       valueFrom:
@@ -90,6 +91,7 @@ spec:
     script: |
       set -x
       env | grep QUAY
+      fuse-overlayfs --version
       buildah --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \

--- a/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
@@ -23,7 +23,7 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: quay.io/buildah/stable:v1.17.0
+    default: quay.io/buildah/stable:v1.26
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
     default: vfs

--- a/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
+++ b/charts/region/pipelines/templates/app-pipeline/tasks/buildah-to-registry.yaml
@@ -89,10 +89,9 @@ spec:
           name: $(params.QUAY_SECRET)
           key: .dockerconfigjson
     script: |
-      set -x
-      env | grep QUAY
       fuse-overlayfs --version
-      buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+      echo $QUAY_PUSH_SECRET > auth.json
+      buildah --storage-driver=$(params.STORAGE_DRIVER) push --authfile auth.json \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)

--- a/charts/region/pipelines/values.yaml
+++ b/charts/region/pipelines/values.yaml
@@ -13,6 +13,7 @@ global:
     email: SOMEWHERE@EXAMPLE.COM
     dev_revision: main
 
+  # Should be set consistently with quay enterprise setup
   imageregistry:
     account: PLAINTEXT
     hostname: quay.io

--- a/values-development.yaml
+++ b/values-development.yaml
@@ -1,3 +1,11 @@
+# Possibly still not the right home...
+devel:
+  appURL: https://github.com/ipbabble/chat-client.git
+  image: chat-client:latest
+  npmbase: quay.io/hybridcloudpatterns/ubi-npm
+  namespace: devsecops-ci
+  roxCTLImage: registry.redhat.io/rh-acs/roxctl:3.0.62.0
+
 global:
   options:
     useCSV: False

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -36,13 +36,6 @@ global:
     password: quayadmin123 
     email: quayadmin@myorg.com
     
-devel:
-  appURL: https://github.com/ipbabble/chat-client.git
-  image: chat-client:latest
-  npmbase: quay.io/hybridcloudpatterns/ubi-npm
-  namespace: devsecops-ci
-  roxCTLImage: registry.redhat.io/rh-acs/roxctl:3.0.62.0
-
 main:
   clusterGroupName: hub
   opp: false

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -32,9 +32,12 @@ global:
     dev_revision: main
 
   quay:
-    account: quayadmin
-    password: quayadmin123 
-    email: quayadmin@myorg.com
+    # Needs to be set consistently between hub and spoke clusters
+    # TODO: Move back to the hub chart, store in a configmap, have an ACM policy distribute to spoke clusters, have spoke look up from configmap 
+    org:
+      name: devel
+      email: devel@myorg.com
+    repo: example
     
 main:
   clusterGroupName: hub

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -42,10 +42,6 @@ devel:
   npmbase: quay.io/hybridcloudpatterns/ubi-npm
   namespace: devsecops-ci
   roxCTLImage: registry.redhat.io/rh-acs/roxctl:3.0.62.0
-  quayorg: develorg
-  quayorgemail: devel@myorg.com
-  quayuser: developer1
-  quayuseremail: developer1@myorg.com
 
 main:
   clusterGroupName: hub

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -38,7 +38,7 @@ global:
     
 devel:
   appURL: https://github.com/ipbabble/chat-client.git
-  image: quay-registry-quay-quay-enterprise.apps.wh-hub.blueprints.rhecoeng.com/chat-client:latest
+  image: chat-client:latest
   npmbase: quay.io/hybridcloudpatterns/ubi-npm
   namespace: devsecops-ci
   roxCTLImage: registry.redhat.io/rh-acs/roxctl:3.0.62.0


### PR DESCRIPTION
Fixes:
* quayadmin password stored in git
* CM script was not idempotent (corrupted the init token)
* Pull secret contained newlines (use base64 -w0)
* Pull secret created with the encrypted pw instead of plaintext
* Pull secret policy constructing with token but pipeline looking for .dockerconfigjson
* Pipeline push did not specify an org/account
* Pipeline push did not use the repo created by CM script
* Update ancient buildah image
* Avoid hung buildah task due to hard coded pvc